### PR TITLE
Fix typos in org names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prow
 
-calf-nursey Prow dashboard: https://prow.calf-nursery.com
+calf-nursery Prow dashboard: https://prow.calf-nursery.com
 
 ## Access Controls
 

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -50,7 +50,7 @@ require_matching_label:
       The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 
 external_plugins:
-  calf-nursey:
+  calf-nursery:
   - name: needs-rebase
     events:
       - issue_comment


### PR DESCRIPTION
```release-note
Fixes typos for org name in README and plugins.yaml
```