### PR TITLE
Enable lifecycle and retitle plugins

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -11,14 +11,16 @@ plugins:
     - hold
     - label
     - lgtm
+    - lifecycle
+    - override
+    - release-note
+    - require-matching-label
+    - retitle
     - transfer-issue
     - trigger
     - verify-owners
     - wip
     - yuks
-    - require-matching-label
-    - release-note
-    - override
   calf-nursery/test-infra:
     plugins:
     - config-updater


### PR DESCRIPTION
**What type of PR is this?**
Enable missing `lifecycle` (to be able to close/reopen issues/PRs) and `retitle` (retitling issues/PRs) plugins. Also reorders plugin alphabetically

/kind feature

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enables lifecycle and retitle plugins
```