### PR TITLE
Update k8s-staging-test-infra images as needed

### DIFF
--- a/jobs/rancher-turtles/rancher-turtles_presubmits.yaml
+++ b/jobs/rancher-turtles/rancher-turtles_presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230824-1c1409fe24-1.27
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.27
         command:
           - make
         args:
@@ -51,7 +51,7 @@ presubmits:
     path_alias: github.com/calf-nursery/rancher-turtles
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230824-1c1409fe24-1.27
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.27
         args:
           - runner.sh
           - "bash"

--- a/jobs/testapp/testapp_presubmits.yaml
+++ b/jobs/testapp/testapp_presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     run_if_changed: '^((scripts)/|main\.go|go\.mod|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230824-1c1409fe24-1.27
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.27
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh


### PR DESCRIPTION
No gcr.io/k8s-testimages/ changes.

Multiple distinct gcr.io/k8s-staging-test-infra changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/kubernetes/test-infra/compare/1c1409fe24...e9e5d470a5 | 2023&#x2011;08&#x2011;24&nbsp;&#x2192;&nbsp;2023&#x2011;09&#x2011;01 | kubekins-e2e(1.27)



Nobody is currently oncall, so falling back to Blunderbuss.

