### PR TITLE
Set 'allow_merge_commit' to true in repos

### DIFF
--- a/config/prow/org.yaml
+++ b/config/prow/org.yaml
@@ -19,7 +19,7 @@ orgs:
 
     repos:
       test-infra:
-        allow_merge_commit: false
+        allow_merge_commit: true
         allow_rebase_merge: true
         allow_squash_merge: false
         description: Calf-nursery workflow & testing infrastructure
@@ -27,7 +27,7 @@ orgs:
         has_wiki: false
         homepage: https://prow.calf-nursery.com
       testapp:
-        allow_merge_commit: false
+        allow_merge_commit: true
         allow_rebase_merge: true
         allow_squash_merge: false
         description: CA sample project


### PR DESCRIPTION
**What type of PR is this?**
/kind support

**What this PR does / why we need it**:
Intermittently, tide is complaining with:

![image](https://github.com/calf-nursery/test-infra/assets/40443040/316dbee7-3bf0-427b-98c1-8af352677649)


And it might be because we disallow it in the peribolos settings (org.yaml). Allowing it should probably help to fix that issue. 


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set 'allow_merge_commit' to true in repos
```